### PR TITLE
[Fix]: Close runtime in between issue resolutions

### DIFF
--- a/resolver/resolver_issue.py
+++ b/resolver/resolver_issue.py
@@ -4,11 +4,13 @@ from argparse import Namespace
 import asyncio
 import pathlib
 import random
+from typing import Any
 import uuid
 
 from openhands.resolver.resolve_issue import IssueResolver
 from openhands.resolver.resolver_output import ResolverOutput
 from openhands.core.config import LLMConfig
+from openhands.runtime import Runtime
 
 from resolver.secrets import Secrets
 from resolver.utils import load_firebase_config
@@ -48,6 +50,16 @@ class PRArenaIssueResolver(IssueResolver):
 
         raw_config = Secrets.get_firebase_config()
         self.firebase_config = load_firebase_config(raw_config)
+
+    async def complete_runtime(
+        self,
+        runtime: Runtime,
+        base_commit: str,
+    ) -> dict[str, Any]:
+        patch = await super().complete_runtime(runtime, base_commit)
+        runtime.close()
+        return patch
+        
 
     async def resolve_issues_with_random_models(self):
         selected_llms = random.sample(self.llm_configs, 2)


### PR DESCRIPTION
We see the following error when attempting to multiple issues back to back 

```
2025-03-03 22:20:12,013 - ERROR - Error: Instance openhands-runtime-1 FAILED to start container!
2025-03-03 22:20:12,013 - ERROR - 409 Client Error for http+docker://localhost/v1.45/containers/create?name=openhands-runtime-1: Conflict ("Conflict. The container name "/openhands-runtime-1" is already in use by container "d11729a421cbe218049ff4f21524312c4ce78c745f17a8ca06c3bfa725b37a47". You have to remove (or rename) that container to be able to reuse that name.")
```

This was because we weren't closing the runtime properly and cleaning up existing containers. This PR ensures that before we complete resolving an issue we clean up the runtime (so that its ready for the next issue resolution step).