### PR TITLE
Fix resolver import error in GitHub workflow

### DIFF
--- a/.github/workflows/pr-arena-resolver.yml
+++ b/.github/workflows/pr-arena-resolver.yml
@@ -90,11 +90,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install git+https://github.com/neulab/pr-arena.git@main
           pip install firebase-admin
+          # Copy the resolver package to /tmp for direct import
+          cp -r $GITHUB_WORKSPACE/resolver /tmp/
 
       - name: Attempt to resolve issues and send the resolver output to Firebase
         id: resolve_issues
         env:
-          PYTHONPATH: ""
+          PYTHONPATH: "/tmp"
           LLM_MODELS: ${{ inputs.llm_models }}
         run: |
           cd /tmp && python -m resolver.resolve_issue \
@@ -166,6 +168,8 @@ jobs:
       
       - name: Wait for user's decision and save it to the GitHub environment
         id: wait_for_decision
+        env:
+          PYTHONPATH: "/tmp"
         run: |
           cd /tmp && python -m resolver.listen_for_decision \
             --repo ${{ github.repository }} \
@@ -200,6 +204,8 @@ jobs:
       - name: Create Pull Request for the selected branch
         id: create_pr
         if: steps.check_decision.outputs.decision_failed != 'true'
+        env:
+          PYTHONPATH: "/tmp"
         run: |
           cd /tmp && python -m resolver.send_pull_request \
             --issue-number ${{ inputs.issue_number }} \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ packages = [
     { include = "resolver" },
 ]
 
+[tool.poetry.scripts]
+resolve_issue = "resolver.resolve_issue:main"
+
 [tool.poetry.dependencies]
 python = "^3.12"
 openhands-ai = { git = "https://github.com/All-Hands-AI/OpenHands.git", rev = "1c4c477b3f9eb38a664f43cff5b83561e5314166" }

--- a/resolver/resolve_issue.py
+++ b/resolver/resolve_issue.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+Entry point for the resolver module that resolves GitHub issues.
+This file serves as a compatibility layer for the GitHub workflow.
+"""
+
+import sys
+import os
+
+# Ensure the current directory is in the Python path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Import the main function from resolver_issue
+from resolver.resolver_issue import main as resolver_main
+
+def main():
+    """
+    Main entry point for the resolver module.
+    """
+    return resolver_main()
+
+if __name__ == "__main__":
+    main()

--- a/resolver/resolver_issue.py
+++ b/resolver/resolver_issue.py
@@ -29,9 +29,17 @@ from resolver.resolver_output import CustomResolverOutput
 from resolver.send_pull_request import (
     initialize_repo,
     apply_patch,
-    make_commit,
-    branch_exists
+    make_commit
 )
+
+def branch_exists(base_url, branch_name, headers):
+    """Check if a branch exists in the remote repository."""
+    import requests
+    try:
+        response = requests.get(f"{base_url}/branches/{branch_name}", headers=headers)
+        return response.status_code == 200
+    except Exception:
+        return False
 
 import firebase_admin
 from firebase_admin import credentials, firestore


### PR DESCRIPTION
This PR fixes the "No module named resolver.resolve_issue" error in the GitHub workflow by:

1. Creating a new `resolve_issue.py` file that imports from `resolver_issue.py`
2. Updating the GitHub workflow to set the correct PYTHONPATH
3. Adding the missing `branch_exists` function to `resolver_issue.py`
4. Updating the pyproject.toml to include the new entry point

These changes ensure that the resolver package can be properly imported during the workflow execution.