### PR TITLE
Fix template path issue in resolver

### DIFF
--- a/resolver/prompts/resolve/basic-conversation-instructions.jinja
+++ b/resolver/prompts/resolve/basic-conversation-instructions.jinja
@@ -1,0 +1,6 @@
+You are an AI assistant helping to resolve GitHub issues. Please follow these guidelines:
+1. Understand the issue thoroughly before proposing solutions
+2. Consider multiple approaches and select the most promising one
+3. Write clean, efficient code with minimal comments
+4. Test your implementation thoroughly, including edge cases
+5. Make focused, minimal changes to address the problem

--- a/resolver/prompts/resolve/basic-followup-conversation-instructions.jinja
+++ b/resolver/prompts/resolve/basic-followup-conversation-instructions.jinja
@@ -1,0 +1,6 @@
+You are an AI assistant helping to resolve GitHub issues. Please follow these guidelines:
+1. Understand the issue thoroughly before proposing solutions
+2. Consider multiple approaches and select the most promising one
+3. Write clean, efficient code with minimal comments
+4. Test your implementation thoroughly, including edge cases
+5. Make focused, minimal changes to address the problem

--- a/resolver/prompts/resolve/basic-followup.jinja
+++ b/resolver/prompts/resolve/basic-followup.jinja
@@ -1,0 +1,17 @@
+The current code is an attempt at fixing one or more issues. The code is not satisfactory and follow up feedback have been provided to address this.
+Please update the code based on the feedback for the repository in /workspace.
+An environment has been set up for you to start working. You may assume all necessary tools are installed.
+
+# Issues addressed 
+{{ issues }}
+
+# Feedback chain
+{{ body }}
+
+IMPORTANT: You should ONLY interact with the environment provided to you AND NEVER ASK FOR HUMAN HELP.
+You SHOULD INCLUDE PROPER INDENTATION in your edit commands.{% if repo_instruction %}
+
+Some basic information about this repository:
+{{ repo_instruction }}{% endif %}
+
+When you think you have fixed the issue through code changes, please run the following command: <execute_bash> exit </execute_bash>.

--- a/resolver/prompts/resolve/basic-with-tests-conversation-instructions.jinja
+++ b/resolver/prompts/resolve/basic-with-tests-conversation-instructions.jinja
@@ -1,0 +1,6 @@
+You are an AI assistant helping to resolve GitHub issues. Please follow these guidelines:
+1. Understand the issue thoroughly before proposing solutions
+2. Consider multiple approaches and select the most promising one
+3. Write clean, efficient code with minimal comments
+4. Test your implementation thoroughly, including edge cases
+5. Make focused, minimal changes to address the problem

--- a/resolver/prompts/resolve/basic-with-tests.jinja
+++ b/resolver/prompts/resolve/basic-with-tests.jinja
@@ -1,0 +1,17 @@
+Please fix the following issue for the repository in /workspace.
+An environment has been set up for you to start working. You may assume all necessary tools are installed.
+
+# Problem Statement
+{{ body }}
+
+IMPORTANT: You should ONLY interact with the environment provided to you AND NEVER ASK FOR HUMAN HELP.
+You SHOULD INCLUDE PROPER INDENTATION in your edit commands.{% if repo_instruction %}
+
+Some basic information about this repository:
+{{ repo_instruction }}{% endif %}
+
+For all changes to actual application code (e.g. in Python or Javascript), add an appropriate test to the testing directory to make sure that the issue has been fixed.
+Run the tests, and if they pass you are done!
+You do NOT need to write new tests if there are only changes to documentation or configuration files.
+
+When finished, run the following command: <execute_bash> exit </execute_bash>.

--- a/resolver/prompts/resolve/basic.jinja
+++ b/resolver/prompts/resolve/basic.jinja
@@ -1,0 +1,13 @@
+Please fix the following issue for the repository in /workspace.
+An environment has been set up for you to start working. You may assume all necessary tools are installed.
+
+# Problem Statement
+{{ body }}
+
+IMPORTANT: You should ONLY interact with the environment provided to you AND NEVER ASK FOR HUMAN HELP.
+You SHOULD INCLUDE PROPER INDENTATION in your edit commands.{% if repo_instruction %}
+
+Some basic information about this repository:
+{{ repo_instruction }}{% endif %}
+
+When you think you have fixed the issue through code changes, please run the following command: <execute_bash> exit </execute_bash>.


### PR DESCRIPTION
## Description
This PR fixes the issue where the resolver is looking for template files in the wrong location. The error occurs because the code in `resolver/resolve_issue.py` is trying to find the template file at `resolver/prompts/resolve/basic-with-tests.jinja`, but this directory structure doesn't exist.

## Solution
Added the necessary template files to the `resolver/prompts/resolve/` directory, including:
- basic.jinja
- basic-with-tests.jinja
- basic-followup.jinja
- And their corresponding conversation-instructions.jinja files

This fixes the error:
```
ERROR:root:<class 'FileNotFoundError'>: [Errno 2] No such file or directory: '/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/resolver/prompts/resolve/basic-with-tests.jinja'
```

## Alternative Solutions Considered
1. Modify the code to look for templates in the openhands_resolver package instead
2. Create a symlink between the directories

The current solution was chosen as it's the simplest and most direct fix for the immediate issue.